### PR TITLE
[newrelic]4桁のレスポンス値に含まれるカンマを除去

### DIFF
--- a/samples/newrelic/newrelic.go
+++ b/samples/newrelic/newrelic.go
@@ -125,7 +125,7 @@ func (n *newrelic) fapAppResponseActions(transactionID string, appResponse *int)
 			return errors.WithStack(err)
 		}
 		var err error
-		*appResponse, err = strconv.Atoi(strings.TrimRight(text, " ms"))
+		*appResponse, err = strconv.Atoi(strings.Replace(strings.TrimRight(text, " ms"), ",", "", -1))
 		if err != nil {
 			n.logger.Printf("Cannot extract app response: %+v", err)
 		}


### PR DESCRIPTION
```shell
newrelic.go:130: Cannot extract app response: strconv.Atoi: parsing "1,260": invalid syntax
```

1000msを超える場合にparse errorが出るので修正しました